### PR TITLE
a stab at honoring timeout settings everywhere

### DIFF
--- a/mysqltest/mysqlTestResult.go
+++ b/mysqltest/mysqlTestResult.go
@@ -1,0 +1,12 @@
+package mysqltest
+
+type MysqlTestResult struct {
+    Entries map[string]string
+}
+
+func (r * MysqlTestResult) AddTextResult(subject string, content string) {
+    if r.Entries == nil {
+      r.Entries = make(map[string]string)
+    }
+    r.Entries[subject] = content
+}


### PR DESCRIPTION
A minor refactor, that instruments a global timeout (Currently based on the -t setting) by employing a MysqlTestResult structure to capture results.

There is 2 channels, and the program will either capture the result structure from the timeout channel after its goroutine is done sleeping, or ideally the actually goroutine sending its reply over the channel before the timeout wins.
